### PR TITLE
Fix `mlmd` TLS library for handshake error 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
-mlmd = "0.2"
+mlmd = { version = "0.2", default-features = false, features = ["runtime-tokio-rustls"] }
 palette = "0.6"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"


### PR DESCRIPTION
Switches the default TLS library of `mlmd` in order to address TLS handshake errors observed on macOS.

```
Error: database error

Caused by:
    0: error occurred while attempting to establish a TLS connection: handshake failure
    1: handshake failure
```